### PR TITLE
Fix integer overflow in length check

### DIFF
--- a/lib/mbr_partition.ml
+++ b/lib/mbr_partition.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+let (--) = Int64.sub
+
 module Make(B: V1_LWT.BLOCK) = struct
   open Lwt
 
@@ -65,9 +67,9 @@ module Make(B: V1_LWT.BLOCK) = struct
       Int64.(add (of_int ((len + t.sec_size - 1) / t.sec_size)) (length t bs))
 
   let adjust_start name op t start_sector buffers =
-    let following_sector = Int64.add start_sector (length t buffers) in
-    if start_sector < 0L || following_sector > t.id.length_sectors
-    then return (`Error (`Unknown (Printf.sprintf "%s %Ld %Ld out of range" name start_sector following_sector)))
+    let buffers_len_sectors = length t buffers in
+    if start_sector < 0L || start_sector > t.id.length_sectors -- buffers_len_sectors
+    then return (`Error (`Unknown (Printf.sprintf "%s %Ld+%Ld out of range" name start_sector buffers_len_sectors)))
     else op t.id.b (Int64.add start_sector t.id.start_sector) buffers
     
   let read = adjust_start "read" B.read

--- a/lib_test/fake_block.ml
+++ b/lib_test/fake_block.ml
@@ -41,13 +41,18 @@ type info = {
   size_sectors: int64; (** Total sectors per device *)
 }
 
+let safe_of_int64 i64 =
+  let i = Int64.to_int i64 in
+  assert (Int64.of_int i = i64);
+  i
+
 let write device sector_start buffers =
   let rec loop dstoff = function
     | [] -> ()
     | x :: xs ->
         Cstruct.blit x 0 device dstoff (Cstruct.len x);
         loop (dstoff + (Cstruct.len x)) xs in
-  loop (Int64.to_int sector_start * sector_size) buffers;
+  loop (safe_of_int64 sector_start * sector_size) buffers;
   `Ok () |> return
 
 let read device sector_start buffers =
@@ -56,7 +61,7 @@ let read device sector_start buffers =
     | x :: xs ->
         Cstruct.blit device dstoff x 0 (Cstruct.len x);
         loop (dstoff + (Cstruct.len x)) xs in
-  loop (Int64.to_int sector_start * sector_size) buffers;
+  loop (safe_of_int64 sector_start * sector_size) buffers;
   `Ok () |> return
 
 let info = {
@@ -65,7 +70,7 @@ let info = {
   size_sectors = 64L;
 }
 
-let size = info.sector_size * Int64.to_int info.size_sectors
+let size = info.sector_size * safe_of_int64 info.size_sectors
 
 let get_info _device = return info
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -59,7 +59,11 @@ let mbr_partition () =
 
     Partition.read part1 (1L) [Cstruct.create (disk_info.Fake_block.sector_size + 1)] >>= function
     | `Ok () -> assert_failure "Out-of-range read allowed!";
-    | `Error msg -> assert_equal_str "read 1 3 out of range" (Fake_block.error_message msg);
+    | `Error msg -> assert_equal_str "read 1+2 out of range" (Fake_block.error_message msg);
+
+    Partition.read part1 (Int64.max_int) [buffer] >>= function
+    | `Ok () -> assert_failure "Out-of-range read allowed!";
+    | `Error msg -> assert_equal_str "read 9223372036854775807+1 out of range" (Fake_block.error_message msg);
 
     Fake_block.read disk 0L [buffer] >>|= fun () -> Cstruct.sub buffer 0 7 |> Cstruct.to_string |> assert_equal_str "sector0";
     Fake_block.read disk 1L [buffer] >>|= fun () -> Cstruct.sub buffer 0 7 |> Cstruct.to_string |> assert_equal_str "sector1";


### PR DESCRIPTION
If the start sector was near Int64.int_max, adding on the length of the
buffer would cause it to wrap and incorrectly pass the test.

This is mainly just paranoia, because the underlying device should
reject the invalid start sector, but it doesn't hurt to be careful...
especially if it uses Int64.to_int to get an integer sector number
(Int64.to_int silently wraps!).