### PR TITLE
Use cmdliner to process commands for the mbr_inspect executable.

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executable
  (name mbr_inspect)
- (libraries mbr))
+ (libraries mbr cstruct))

--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executable
  (name mbr_inspect)
- (libraries mbr cstruct))
+ (libraries mbr cstruct cmdliner))

--- a/bin/mbr_inspect.ml
+++ b/bin/mbr_inspect.ml
@@ -1,9 +1,10 @@
-let print_mbr_fields mbr =
-  let bootstrap_code =
-    Cstruct.to_hex_string (Cstruct.of_string mbr.Mbr.bootstrap_code)
-  in
+open Cmdliner
+
+let print_mbr_fields print_bootstrap_code mbr =
   Printf.printf "MBR fields:\n";
-  Printf.printf "  bootstrap_code: %s\n" bootstrap_code;
+  if print_bootstrap_code then
+    Printf.printf "  bootstrap_code: %s\n"
+      (Cstruct.to_hex_string (Cstruct.of_string mbr.Mbr.bootstrap_code));
   Printf.printf "  original_physical_drive: %d\n"
     mbr.Mbr.original_physical_drive;
   Printf.printf "  seconds: %d\n" mbr.Mbr.seconds;
@@ -32,33 +33,32 @@ let print_mbr_fields mbr =
       Printf.printf "    size_sectors: %ld\n" part.Mbr.Partition.sectors)
     mbr.partitions
 
-let read_mbr mbr =
-  let ic = open_in_bin mbr in
-  let buf = Bytes.create Mbr.sizeof in
-  let () = really_input ic buf 0 Mbr.sizeof in
-  close_in ic;
-  match Mbr.unmarshal (Cstruct.of_bytes buf) with
-  | Ok mbr -> mbr
-  | Error msg ->
-      Printf.printf "Failed to read MBR from %s: %s\n" mbr msg;
-      exit 1
+let read_mbr print_bootstrap_code mbrs =
+  List.iter
+    (fun mbr ->
+      let ic = open_in_bin mbr in
+      let buf = Bytes.create Mbr.sizeof in
+      let () = really_input ic buf 0 Mbr.sizeof in
+      close_in ic;
+      match Mbr.unmarshal (Cstruct.of_bytes buf) with
+      | Ok mbr -> print_mbr_fields print_bootstrap_code mbr
+      | Error msg ->
+          Printf.printf "Failed to read MBR from %s: %s\n" mbr msg;
+          exit 1)
+    mbrs
 
-let () =
-  let command = Filename.basename Sys.argv.(0) in
-  if Array.length Sys.argv < 2 then (
-    Printf.printf
-      "Inspect MBR Headers: \n\
-      \ Usage %s <file1> [<file2> ...]\n\
-      \ You must pass in at least one MBR header\n"
-      command;
-    exit 1)
-  else
-    let mbr_files =
-      Array.of_list
-        (Array.to_list (Array.sub Sys.argv 1 (Array.length Sys.argv - 1)))
-    in
-    Array.iter
-      (fun mbr_file ->
-        let mbr = read_mbr mbr_file in
-        print_mbr_fields mbr)
-      mbr_files
+let mbrs = Arg.(non_empty & pos_all file [] & info [] ~docv:"MBR")
+
+let print_bootstrap_code =
+  let doc = "Print the bootstrap code of the disks images." in
+  Arg.(value & flag & info [ "b"; "booststrap-code" ] ~doc)
+
+let cmd =
+  let doc =
+    "Inspect the Master Boot Record (MBR) headers of one or more disk images."
+  in
+  let info = Cmd.info "MBR Inspect" ~version:"1.0.0" ~doc in
+  Cmd.v info Term.(const read_mbr $ print_bootstrap_code $ mbrs)
+
+let main () = exit (Cmd.eval cmd)
+let () = main ()

--- a/bin/mbr_inspect.ml
+++ b/bin/mbr_inspect.ml
@@ -33,7 +33,7 @@ let print_mbr_fields print_bootstrap_code mbr =
       Printf.printf "    size_sectors: %ld\n" part.Mbr.Partition.sectors)
     mbr.partitions
 
-let read_mbr print_bootstrap_code mbrs =
+let read_mbrs print_bootstrap_code mbrs =
   List.iter
     (fun mbr ->
       let ic = open_in_bin mbr in
@@ -47,7 +47,7 @@ let read_mbr print_bootstrap_code mbrs =
           exit 1)
     mbrs
 
-let mbrs = Arg.(non_empty & pos_all file [] & info [] ~docv:"[DISK IMAGES]")
+let mbrs = Arg.(non_empty & pos_all file [] & info [] ~docv:"disk_images")
 
 let print_bootstrap_code =
   let doc = "Print the bootstrap code of the disks images." in
@@ -58,7 +58,7 @@ let cmd =
     "Inspect the Master Boot Record (MBR) headers of one or more disk images."
   in
   let info = Cmd.info "mbr_inspect" ~version:"1.0.0" ~doc in
-  Cmd.v info Term.(const read_mbr $ print_bootstrap_code $ mbrs)
+  Cmd.v info Term.(const read_mbrs $ print_bootstrap_code $ mbrs)
 
 let main () = exit (Cmd.eval cmd)
 let () = main ()

--- a/bin/mbr_inspect.ml
+++ b/bin/mbr_inspect.ml
@@ -47,7 +47,7 @@ let read_mbr print_bootstrap_code mbrs =
           exit 1)
     mbrs
 
-let mbrs = Arg.(non_empty & pos_all file [] & info [] ~docv:"MBR")
+let mbrs = Arg.(non_empty & pos_all file [] & info [] ~docv:"[DISK IMAGES]")
 
 let print_bootstrap_code =
   let doc = "Print the bootstrap code of the disks images." in
@@ -57,7 +57,7 @@ let cmd =
   let doc =
     "Inspect the Master Boot Record (MBR) headers of one or more disk images."
   in
-  let info = Cmd.info "MBR Inspect" ~version:"1.0.0" ~doc in
+  let info = Cmd.info "mbr_inspect" ~version:"1.0.0" ~doc in
   Cmd.v info Term.(const read_mbr $ print_bootstrap_code $ mbrs)
 
 let main () = exit (Cmd.eval cmd)

--- a/bin/mbr_inspect.ml
+++ b/bin/mbr_inspect.ml
@@ -1,6 +1,9 @@
 let print_mbr_fields mbr =
+  let bootstrap_code =
+    Cstruct.to_hex_string (Cstruct.of_string mbr.Mbr.bootstrap_code)
+  in
   Printf.printf "MBR fields:\n";
-  Printf.printf "  bootstrap_code: \"\"\n";
+  Printf.printf "  bootstrap_code: %s\n" bootstrap_code;
   Printf.printf "  original_physical_drive: %d\n"
     mbr.Mbr.original_physical_drive;
   Printf.printf "  seconds: %d\n" mbr.Mbr.seconds;

--- a/mbr-format.opam
+++ b/mbr-format.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.4.0"}
   "lwt"
-  "cstruct" {>= "6.0.0"}
+  "cstruct" {>= "6.2.0"}
   "ppx_cstruct"
   "fmt" {with-test}
   "alcotest" {with-test}

--- a/mbr-format.opam
+++ b/mbr-format.opam
@@ -14,7 +14,8 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.4.0"}
   "lwt"
-  "cstruct" {>= "6.2.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct" {dev & >= "6.2.0"}
   "ppx_cstruct"
   "fmt" {with-test}
   "alcotest" {with-test}


### PR DESCRIPTION
closes #21 

## Outline
This PR restructures the `mbr_inspect.ml` file to use the `cmdliner` package.
The command has an optional flag `-b` or `--bootstrap-code` which toggles if to display the bootstrap code of the MBR header.

The `cmdliner` package also generates a nice looking help file which can be opened by using the flag `--help`.

It's a great improvement to the `mbr_inspect.ml` executable.

## Some screenshots:
### `mbr_inspect.exe -- help`
![image](https://user-images.githubusercontent.com/111846546/225581281-393ff71c-0bd5-48ae-8680-a3e24fd24099.png)

### `mbr_inspect.exe test.img` : no bootstrap code
![image](https://user-images.githubusercontent.com/111846546/225581486-98bd6357-2584-428f-80ad-d94bb849055e.png)

### `mbr_inspect.exe -b test.img`: print bootstrap code
![image](https://user-images.githubusercontent.com/111846546/225581879-3b287ef2-eec6-497c-ae58-3def00c431a7.png)


cc @reynir 