### PR TITLE
Write data to partition, read stdin or file

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executables
- (names mbr_inspect read_partition)
+ (names mbr_inspect read_partition write_partition)
  (libraries mbr cstruct cmdliner))

--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executables
  (names mbr_inspect read_partition write_partition)
- (libraries mbr cstruct cmdliner))
+ (libraries mbr cstruct cmdliner unix))

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -31,11 +31,11 @@ let read_line () =
 
 let read_file file_path =
   let ic = open_in_bin file_path in
-  let buf = Buffer.create 1024 in
+  let buf = Buffer.create 2048 in
   try
     while true do
-      let bytes = Bytes.create 1024 in
-      let bytes_read = input ic bytes 0 1024 in
+      let bytes = Bytes.create 2048 in
+      let bytes_read = input ic bytes 0 2048 in
       if bytes_read = 0 then raise Exit
       else Buffer.add_subbytes buf bytes 0 bytes_read
     done;

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -117,7 +117,7 @@ let input_data =
   Arg.(value & opt (some string) None & info [ "d"; "data" ] ~doc)
 
 let cmd =
-  let doc = "Read the contents of a partition" in
+  let doc = "Write data into a partition" in
   let info = Cmd.info "write_partition" ~version:"1.0.0" ~doc in
   Cmd.v info
     Term.(const write_to_partition $ mbr $ partition_number $ input_data)

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -46,6 +46,15 @@ let read_file file_path =
       close_in ic;
       raise exn
 
+let write_partition_data_internal mbr start_sector output_buffer =
+  let sector_size = 512 in
+  let fd = open_out_gen [ Open_wronly; Open_creat; Open_binary ] 0o644 mbr in
+  let mbr_size = read_mbr mbr |> snd in
+  let pos = (start_sector * sector_size) + mbr_size in
+  let () = seek_out fd pos in
+  let () = output_bytes fd output_buffer in
+  close_out fd
+  
 let write_to_partition mbr partition_number input_data =
   let partition = get_partition_info mbr partition_number in
   let start_sector, num_sectors, sector_size =

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -1,5 +1,16 @@
 open Cmdliner
 
+let read_mbr mbr =
+  let ic = open_in_bin mbr in
+  let buf = Bytes.create Mbr.sizeof in
+  let () = really_input ic buf 0 Mbr.sizeof in
+  close_in ic;
+  match Mbr.unmarshal (Cstruct.of_bytes buf) with
+  | Ok mbr -> (mbr, Mbr.sizeof)
+  | Error msg ->
+      Printf.printf "Failed to read MBR from %s: %s\n" mbr msg;
+      exit 1
+      
 let mbr =
   let doc = "The disk image containing the partition" in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -16,6 +16,7 @@ let get_partition_info mbr partition_num =
   List.nth mbr.Mbr.partitions (partition_num - 1)
 
 let calculate_partition_info partition =
+  (* FIXME: Use Int32.unsigned_to_int *)
   let start_sector =
     Int32.to_int partition.Mbr.Partition.first_absolute_sector_lba
   in
@@ -23,86 +24,53 @@ let calculate_partition_info partition =
   let sector_size = 512 in
   (start_sector, num_sectors, sector_size)
 
-let read_multiline () =
-  let rec read_lines acc =
-    try
-      let line = input_line stdin in
-      if String.length line > 0 && line.[0] = '>' then
-        String.concat "\n" (List.rev acc)
-      else read_lines (line :: acc)
-    with End_of_file -> String.concat "\n" (List.rev acc)
+let copy ic oc max_bytes =
+  let buf_len = 4096 in
+  let buf = Bytes.create buf_len in
+  let rec loop i =
+    let len = input ic buf 0 buf_len in
+    if len > 0 then
+      let len' = min len (max_bytes - i) in
+      output oc buf 0 len';
+      if i + len > max_bytes then
+        failwith "Trying to write more than can fit in partition";
+      loop (i + len')
+    else
+      ()
   in
-  read_lines []
-
-let read_file file_path chunk_size pos =
-  Printf.printf "\nRead position in data file: %d\n" pos;
-  let ic = open_in_bin file_path in
-  try
-    seek_in ic pos;
-    let bytes = Bytes.create chunk_size in
-    let bytes_read = input ic bytes 0 chunk_size in
-    close_in ic;
-    Bytes.sub_string bytes 0 bytes_read
-  with exn ->
-    close_in ic;
-    raise exn
-
-let write_partition_data_internal fd start_sector write_sector output_buffer =
-  Printf.printf "Position written on disk: %d\n" write_sector;
-  let sector_size = 512 in
-  let pos = (start_sector * sector_size) + write_sector in
-  let () = seek_out fd pos in
-  let () = output_bytes fd output_buffer in
-  ()
+  loop 0
 
 let write_to_partition mbr partition_number input_data =
   let partition = get_partition_info mbr partition_number in
   let start_sector, num_sectors, sector_size =
     calculate_partition_info partition
   in
-  let start_position = 0 in
-  let data_chunk_size = 1024 in
-  let buffer, data_size =
+  if start_sector = 0 then
+    Printf.ksprintf failwith "Writing to partition %d would overwrite the MBR header" partition_number;
+  let ic, data_size =
     match input_data with
     | None ->
-        let input_string = Bytes.of_string (read_multiline ()) in
-        (input_string, Bytes.length input_string)
+        (stdin, None)
     | Some file_path ->
         let file_info = Unix.stat file_path in
         let data_size = file_info.st_size in
-        let file_contents =
-          read_file file_path data_chunk_size start_position |> Bytes.of_string
-        in
-        (file_contents, data_size)
+        let ic = open_in_bin file_path in
+        (ic, Some data_size)
   in
   let partition_size = num_sectors * sector_size in
-  Printf.printf "Total input size: %d\n" data_size;
-  Printf.printf "Chunk size: %d\n" data_chunk_size;
+  Option.iter (fun data_size ->
+      Printf.printf "Total input size: %d\n" data_size)
+    data_size;
   Printf.printf "Total Partition size: %d\n" partition_size;
-  if data_size > partition_size then failwith "Input is too large for partition"
-  else (
-    Printf.printf "\nBegin writing to partition:- \n";
-    let fd = open_out_gen [ Open_wronly; Open_binary ] 0o644 mbr in
-    let rec write_chunks start_pos =
-      if start_pos >= data_size then ()
-      else
-        let chunk_size = min data_chunk_size (data_size - start_pos) in
-        if chunk_size <= 0 then ()
-        else
-          let chunk =
-            match input_data with
-            | None ->
-                let chunk = Bytes.create chunk_size in
-                Bytes.blit buffer start_pos chunk 0 chunk_size;
-                chunk
-            | Some file_path ->
-                read_file file_path chunk_size start_pos |> Bytes.of_string
-          in
-          write_partition_data_internal fd start_sector start_pos chunk;
-          write_chunks (start_pos + chunk_size)
-    in
-    write_chunks 0;
-    close_out fd)
+  Option.iter (fun data_size ->
+      if data_size > partition_size then failwith "Input is too large for partition")
+    data_size;
+  Printf.printf "\nBegin writing to partition:- \n";
+  let oc = open_out_gen [ Open_wronly; Open_binary ] 0o644 mbr in
+  seek_out oc (start_sector * sector_size);
+  copy ic oc partition_size;
+  close_out_noerr oc;
+  close_in_noerr ic
 
 let mbr =
   let doc = "The disk image containing the partition" in
@@ -114,7 +82,7 @@ let partition_number =
 
 let input_data =
   let doc = "The data to write to the partition." in
-  Arg.(value & opt (some string) None & info [ "d"; "data" ] ~doc)
+  Arg.(value & opt (some string) None & info [ "d"; "data" ] ~doc ~docv:"FILE")
 
 let cmd =
   let doc = "Write data into a partition" in

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -11,6 +11,10 @@ let read_mbr mbr =
       Printf.printf "Failed to read MBR from %s: %s\n" mbr msg;
       exit 1
       
+let get_partition_info mbr partition_num =
+  let mbr = read_mbr mbr |> fst in
+  List.nth mbr.Mbr.partitions (partition_num - 1)
+
 let mbr =
   let doc = "The disk image containing the partition" in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -54,7 +54,7 @@ let write_partition_data_internal mbr start_sector output_buffer =
   let () = seek_out fd pos in
   let () = output_bytes fd output_buffer in
   close_out fd
-  
+
 let write_to_partition mbr partition_number input_data =
   let partition = get_partition_info mbr partition_number in
   let start_sector, num_sectors, sector_size =

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -49,8 +49,7 @@ let read_file file_path =
 let write_partition_data_internal mbr start_sector output_buffer =
   let sector_size = 512 in
   let fd = open_out_gen [ Open_wronly; Open_creat; Open_binary ] 0o644 mbr in
-  let mbr_size = read_mbr mbr |> snd in
-  let pos = (start_sector * sector_size) + mbr_size in
+  let pos = start_sector * sector_size in
   let () = seek_out fd pos in
   let () = output_bytes fd output_buffer in
   close_out fd

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -10,10 +10,18 @@ let read_mbr mbr =
   | Error msg ->
       Printf.printf "Failed to read MBR from %s: %s\n" mbr msg;
       exit 1
-      
+
 let get_partition_info mbr partition_num =
   let mbr = read_mbr mbr |> fst in
   List.nth mbr.Mbr.partitions (partition_num - 1)
+
+let calculate_partition_info partition =
+  let start_sector =
+    Int32.to_int partition.Mbr.Partition.first_absolute_sector_lba
+  in
+  let num_sectors = Int32.to_int partition.Mbr.Partition.sectors in
+  let sector_size = 512 in
+  (start_sector, num_sectors, sector_size)
 
 let mbr =
   let doc = "The disk image containing the partition" in

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -29,6 +29,23 @@ let read_line () =
     line ^ "\n"
   with End_of_file -> ""
 
+let read_file file_path =
+  let ic = open_in_bin file_path in
+  let buf = Buffer.create 1024 in
+  try
+    while true do
+      let bytes = Bytes.create 1024 in
+      let bytes_read = input ic bytes 0 1024 in
+      if bytes_read = 0 then raise Exit
+      else Buffer.add_subbytes buf bytes 0 bytes_read
+    done;
+    assert false (* Unreachable *)
+  with
+  | Exit -> Buffer.contents buf
+  | exn ->
+      close_in ic;
+      raise exn
+
 let mbr =
   let doc = "The disk image containing the partition" in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -48,7 +48,7 @@ let read_file file_path =
 
 let write_partition_data_internal mbr start_sector output_buffer =
   let sector_size = 512 in
-  let fd = open_out_gen [ Open_wronly; Open_creat; Open_binary ] 0o644 mbr in
+  let fd = open_out_gen [ Open_wronly; Open_binary ] 0o644 mbr in
   let pos = start_sector * sector_size in
   let () = seek_out fd pos in
   let () = output_bytes fd output_buffer in

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -23,54 +23,86 @@ let calculate_partition_info partition =
   let sector_size = 512 in
   (start_sector, num_sectors, sector_size)
 
-let read_line () =
-  try
-    let line = input_line stdin in
-    line ^ "\n"
-  with End_of_file -> ""
+let read_multiline () =
+  let rec read_lines acc =
+    try
+      let line = input_line stdin in
+      if String.length line > 0 && line.[0] = '>' then
+        String.concat "\n" (List.rev acc)
+      else read_lines (line :: acc)
+    with End_of_file -> String.concat "\n" (List.rev acc)
+  in
+  read_lines []
 
-let read_file file_path =
+let read_file file_path chunk_size pos =
+  Printf.printf "\nRead position in data file: %d\n" pos;
   let ic = open_in_bin file_path in
-  let buf = Buffer.create 2048 in
   try
-    while true do
-      let bytes = Bytes.create 2048 in
-      let bytes_read = input ic bytes 0 2048 in
-      if bytes_read = 0 then raise Exit
-      else Buffer.add_subbytes buf bytes 0 bytes_read
-    done;
-    assert false (* Unreachable *)
-  with
-  | Exit -> Buffer.contents buf
-  | exn ->
-      close_in ic;
-      raise exn
+    seek_in ic pos;
+    let bytes = Bytes.create chunk_size in
+    let bytes_read = input ic bytes 0 chunk_size in
+    close_in ic;
+    Bytes.sub_string bytes 0 bytes_read
+  with exn ->
+    close_in ic;
+    raise exn
 
-let write_partition_data_internal mbr start_sector output_buffer =
+let write_partition_data_internal fd start_sector write_sector output_buffer =
+  Printf.printf "Position written on disk: %d\n" write_sector;
   let sector_size = 512 in
-  let fd = open_out_gen [ Open_wronly; Open_binary ] 0o644 mbr in
-  let pos = start_sector * sector_size in
+  let pos = (start_sector * sector_size) + write_sector in
   let () = seek_out fd pos in
   let () = output_bytes fd output_buffer in
-  close_out fd
+  ()
 
 let write_to_partition mbr partition_number input_data =
   let partition = get_partition_info mbr partition_number in
   let start_sector, num_sectors, sector_size =
     calculate_partition_info partition
   in
-  let buffer =
+  let start_position = 0 in
+  let data_chunk_size = 1024 in
+  let buffer, data_size =
     match input_data with
-    | None -> Bytes.of_string (read_line ())
+    | None ->
+        let input_string = Bytes.of_string (read_multiline ()) in
+        (input_string, Bytes.length input_string)
     | Some file_path ->
-        read_file file_path |> Bytes.of_string (* Convert buffer to bytes *)
+        let file_info = Unix.stat file_path in
+        let data_size = file_info.st_size in
+        let file_contents =
+          read_file file_path data_chunk_size start_position |> Bytes.of_string
+        in
+        (file_contents, data_size)
   in
-  let output_buffer = Bytes.create (num_sectors * sector_size) in
-  let input_buffer_size = Bytes.length buffer in
-  if input_buffer_size > num_sectors * sector_size then
-    failwith "Input is too large for partition"
-  else Bytes.blit buffer 0 output_buffer 0 input_buffer_size;
-  write_partition_data_internal mbr start_sector output_buffer
+  let partition_size = num_sectors * sector_size in
+  Printf.printf "Total input size: %d\n" data_size;
+  Printf.printf "Chunk size: %d\n" data_chunk_size;
+  Printf.printf "Total Partition size: %d\n" partition_size;
+  if data_size > partition_size then failwith "Input is too large for partition"
+  else (
+    Printf.printf "\nBegin writing to partition:- \n";
+    let fd = open_out_gen [ Open_wronly; Open_binary ] 0o644 mbr in
+    let rec write_chunks start_pos =
+      if start_pos >= data_size then ()
+      else
+        let chunk_size = min data_chunk_size (data_size - start_pos) in
+        if chunk_size <= 0 then ()
+        else
+          let chunk =
+            match input_data with
+            | None ->
+                let chunk = Bytes.create chunk_size in
+                Bytes.blit buffer start_pos chunk 0 chunk_size;
+                chunk
+            | Some file_path ->
+                read_file file_path chunk_size start_pos |> Bytes.of_string
+          in
+          write_partition_data_internal fd start_sector start_pos chunk;
+          write_chunks (start_pos + chunk_size)
+    in
+    write_chunks 0;
+    close_out fd)
 
 let mbr =
   let doc = "The disk image containing the partition" in
@@ -86,7 +118,7 @@ let input_data =
 
 let cmd =
   let doc = "Read the contents of a partition" in
-  let info = Cmd.info "read_partition" ~version:"1.0.0" ~doc in
+  let info = Cmd.info "write_partition" ~version:"1.0.0" ~doc in
   Cmd.v info
     Term.(const write_to_partition $ mbr $ partition_number $ input_data)
 

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -1,0 +1,22 @@
+open Cmdliner
+
+let mbr =
+  let doc = "The disk image containing the partition" in
+  Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)
+
+let partition_number =
+  let doc = "The partition number to write to" in
+  Arg.(required & pos 1 (some int) None & info [] ~docv:"partition_number" ~doc)
+
+let input_data =
+  let doc = "The data to write to the partition." in
+  Arg.(value & opt (some string) None & info [ "d"; "data" ] ~doc)
+
+let cmd =
+  let doc = "Read the contents of a partition" in
+  let info = Cmd.info "read_partition" ~version:"1.0.0" ~doc in
+  Cmd.v info
+    Term.(const write_to_partition $ mbr $ partition_number $ input_data)
+
+let main () = exit (Cmd.eval cmd)
+let () = main ()

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -23,6 +23,12 @@ let calculate_partition_info partition =
   let sector_size = 512 in
   (start_sector, num_sectors, sector_size)
 
+let read_line () =
+  try
+    let line = input_line stdin in
+    line ^ "\n"
+  with End_of_file -> ""
+
 let mbr =
   let doc = "The disk image containing the partition" in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)


### PR DESCRIPTION
part of #14 
## Outline
This creates a new file `write_partition.ml` that can copy a file into a partition, or receive input from `stdin` and copy it into the partition.
We are using the `cmdliner` package to read arguments from the command line. It also provides a helpful `--help` flag which can displays a user manual. 
Basically we read in a disk image, unmarshal it's MBR header to get the partition table, grab the specific partition we want to read from. After getting this partition, we calculate information about it's sectors and then read the data from these sectors.

## Usage

After building, the command can be called with:

```bash
write_partition.exe test.img 2
Writing into partition 2
```
- test.img : The disk image which contains the partition.
- 2 : The partition number we want to read from.
- `writing into partition 2`: the data to write into partition 2. 

To write a file into the partition:

```bash
write_partition.exe -d file.txt test.img 2
```
This will copy all the contents of `file.txt` into partition 2.

## Simple Test
Create a new text file with some text:
```bash
echo "Simple file for testing" > file.txt
```
Create a new disk image with 3 partitions:

```bash
fallocate -l test.img 2M`
parted --align none test.img mklabel msdos
parted --align none test.img mkpart primary 1s 2s
parted --align none test.img mkpart primary 3s 4s
parted --align none test.img mkpart primary 5s 6s
```
Add the text file to the partition 1
```bash
write_partition.exe -d file.txt test.img 1
```
Add some other text to partition 2
```bash
write_partition.exe test.img 2
Write this to partition 2
```
### Verify the data was written to both partitions:
```bash
read_partition.exe test.img 1
read_partition.exe test.img 2
```
### Observation
The data in partition1 and 2 should be printed to stdout. Partition 1 should contain what was in `file.txt` and partition 2 should contain what was typed in stdin.

## UPDATE
To write multiline comments, you just keep using the enter key to write the next line. To stop writing, you use this character `>`