### PR TITLE
Resize partitions in a disk image.

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executables
- (names mbr_inspect read_partition write_partition)
+ (names mbr_inspect read_partition write_partition resize_partition)
  (libraries mbr cstruct cmdliner unix))

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -19,7 +19,9 @@ let calculate_partition_info partition =
   let start_sector =
     Int32.to_int partition.Mbr.Partition.first_absolute_sector_lba
   in
+  let num_sectors = Int32.to_int partition.Mbr.Partition.sectors in
   let sector_size = 512 in
+  Printf.printf "Current partition size: %d bytes\n" (num_sectors * sector_size);
   (start_sector, sector_size)
 
 let make_new_partition partition start_sector sector_size new_size =
@@ -31,6 +33,8 @@ let make_new_partition partition start_sector sector_size new_size =
   else
     let new_num_sectors = new_size / sector_size in
     let new_end_sector = start_sector + new_num_sectors in
+    Printf.printf "New partition size: %d bytes\n"
+      (new_num_sectors * sector_size);
     match
       Mbr.Partition.make ~active:partition.Mbr.Partition.active
         ~partition_type:partition.Mbr.Partition.ty

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -28,8 +28,8 @@ let make_new_partition partition start_sector sector_size new_size =
   if new_size mod sector_size <> 0 then
     Printf.ksprintf failwith
       "Partition cannot be resized. New size of %d bytes does not align to \
-       sectors."
-      new_size
+       sectors. New size must be a multiple of %d"
+      new_size sector_size
   else
     let new_num_sectors = new_size / sector_size in
     let new_end_sector = start_sector + new_num_sectors in
@@ -50,6 +50,7 @@ let replace_partition_in_partition_table mbr partition_number new_partition =
   in
   List.mapi update_partition mbr.Mbr.partitions
 
+(* Mbr.make smart constructor checks for partition overlap, more than 1 active partitions and too many partitions *)
 let make_new_mbr mbr new_partition_table =
   match Mbr.make ~disk_signature:mbr.Mbr.disk_signature new_partition_table with
   | Ok new_mbr -> new_mbr

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -77,16 +77,19 @@ let resize_partition mbr partition_number new_size =
   close_out_noerr oc
 
 let mbr =
-  let doc = "The disk image containing the partition" in
+  let doc = "The disk image containing the partition." in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)
 
 let partition_number =
-  let doc = "The partition number to resize" in
+  let doc = "The partition number to resize. Indexed from 1 to 4." in
   Arg.(required & pos 1 (some int) None & info [] ~docv:"partition_number" ~doc)
 
 let new_size =
-  let doc = "The new size of the partition" in
-  Arg.(required & pos 2 (some int) None & info [] ~docv:"new_Size" ~doc)
+  let doc =
+    "The new size of the partition in bytes. The size has to be aligned with \
+     the sector size, i.e. a multiple of 512."
+  in
+  Arg.(required & pos 2 (some int) None & info [] ~docv:"new_size" ~doc)
 
 let cmd =
   let doc = "Resize a partition" in

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -57,6 +57,13 @@ let resize_partition disk partition_number _new_size =
     replace_partition_in_partition_table mbr partition_number new_partition
   in
   let new_mbr = make_new_mbr mbr new_partition_table in
+  let oc = open_out_gen [ Open_wronly; Open_binary ] 0o644 disk in
+  seek_out oc 0;
+  let buf = Cstruct.create Mbr.sizeof in
+  Mbr.marshal buf new_mbr;
+  let mbr_bytes = Cstruct.to_bytes buf in
+  output oc mbr_bytes 0 Mbr.sizeof;
+  close_out_noerr oc
   
 let mbr =
   let doc = "The disk image containing the partition" in

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -41,6 +41,11 @@ let replace_partition_in_partition_table mbr partition_number new_partition =
   in
   List.mapi update_partition mbr.Mbr.partitions
 
+let make_new_mbr mbr new_partition_table =
+  match Mbr.make ~disk_signature:mbr.Mbr.disk_signature new_partition_table with
+  | Ok new_mbr -> new_mbr
+  | Error msg -> failwith msg
+
 let resize_partition disk partition_number _new_size =
   let disk = mbr in
   let mbr = read_mbr mbr |> fst in
@@ -51,7 +56,8 @@ let resize_partition disk partition_number _new_size =
   let new_partition_table =
     replace_partition_in_partition_table mbr partition_number new_partition
   in
-
+  let new_mbr = make_new_mbr mbr new_partition_table in
+  
 let mbr =
   let doc = "The disk image containing the partition" in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -34,7 +34,12 @@ let make_new_partition partition start_sector sector_size new_size =
   with
   | Ok new_partition -> new_partition
   | Error msg -> failwith msg
-  
+
+let replace_partition_in_partition_table mbr partition_number new_partition =
+  let update_partition i p =
+    if i = partition_number - 1 then new_partition else p
+  in
+  List.mapi update_partition mbr.Mbr.partitions
 
 let resize_partition disk partition_number _new_size =
   let disk = mbr in
@@ -43,6 +48,9 @@ let resize_partition disk partition_number _new_size =
   let start_sector, sector_size = calculate_partition_info partition in
   let new_partition =
     make_new_partition partition start_sector sector_size new_size
+  let new_partition_table =
+    replace_partition_in_partition_table mbr partition_number new_partition
+  in
 
 let mbr =
   let doc = "The disk image containing the partition" in

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -1,7 +1,35 @@
 open Cmdliner
 
+let read_mbr mbr =
+  let ic = open_in_bin mbr in
+  let buf = Bytes.create Mbr.sizeof in
+  let () = really_input ic buf 0 Mbr.sizeof in
+  close_in ic;
+  match Mbr.unmarshal (Cstruct.of_bytes buf) with
+  | Ok mbr -> (mbr, Mbr.sizeof)
+  | Error msg ->
+      Printf.printf "Failed to read MBR from %s: %s\n" mbr msg;
+      exit 1
+
+let get_partition_info mbr partition_num =
+  let mbr = read_mbr mbr |> fst in
+  List.nth mbr.Mbr.partitions (partition_num - 1)
+
+let calculate_partition_info partition =
+  (* FIXME: Use Int32.unsigned_to_int *)
+  let start_sector =
+    Int32.to_int partition.Mbr.Partition.first_absolute_sector_lba
+  in
+  let num_sectors = Int32.to_int partition.Mbr.Partition.sectors in
+  let sector_size = 512 in
+  (start_sector, num_sectors, sector_size)
+
 (*to be implemented*)
-let resize_partition _disk _partition_number _new_size =
+let resize_partition disk partition_number _new_size =
+  let partition = get_partition_info disk partition_number in
+  let _start_sector, _num_sectors, _sector_size =
+    calculate_partition_info partition
+  in
   ()
 
 let mbr =

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -1,0 +1,26 @@
+open Cmdliner
+
+(*to be implemented*)
+let resize_partition _disk _partition_number _new_size =
+  ()
+
+let mbr =
+  let doc = "The disk image containing the partition" in
+  Arg.(required & pos 0 (some file) None & info [] ~docv:"disk_image" ~doc)
+
+let partition_number =
+  let doc = "The partition number to resize" in
+  Arg.(required & pos 1 (some int) None & info [] ~docv:"partition_number" ~doc)
+
+let new_size =
+  let doc = "The new size of the partition" in
+  Arg.(required & pos 2 (some int) None & info [] ~docv:"new_Size" ~doc)
+
+let cmd =
+  let doc = "Resize a partition" in
+  let info = Cmd.info "resize_partition" ~version:"1.0.0" ~doc in
+  Cmd.v info
+    Term.(const resize_partition $ mbr $ partition_number $ new_size)
+
+let main () = exit (Cmd.eval cmd)
+let () = main ()

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -20,11 +20,9 @@ let calculate_partition_info partition =
   let start_sector =
     Int32.to_int partition.Mbr.Partition.first_absolute_sector_lba
   in
-  let num_sectors = Int32.to_int partition.Mbr.Partition.sectors in
   let sector_size = 512 in
-  (start_sector, num_sectors, sector_size)
+  (start_sector, sector_size)
 
-(*to be implemented*)
 let resize_partition disk partition_number _new_size =
   let partition = get_partition_info disk partition_number in
   let _start_sector, _num_sectors, _sector_size =

--- a/bin/resize_partition.ml
+++ b/bin/resize_partition.ml
@@ -23,12 +23,26 @@ let calculate_partition_info partition =
   let sector_size = 512 in
   (start_sector, sector_size)
 
+let make_new_partition partition start_sector sector_size new_size =
+  let new_num_sectors = new_size / sector_size in
+  let new_end_sector = start_sector + new_num_sectors in
+  match
+    Mbr.Partition.make ~active:partition.Mbr.Partition.active
+      ~partition_type:partition.Mbr.Partition.ty
+      partition.Mbr.Partition.first_absolute_sector_lba
+      (Int32.of_int new_end_sector)
+  with
+  | Ok new_partition -> new_partition
+  | Error msg -> failwith msg
+  
+
 let resize_partition disk partition_number _new_size =
-  let partition = get_partition_info disk partition_number in
-  let _start_sector, _num_sectors, _sector_size =
-    calculate_partition_info partition
-  in
-  ()
+  let disk = mbr in
+  let mbr = read_mbr mbr |> fst in
+  let partition = get_partition_info mbr partition_number in
+  let start_sector, sector_size = calculate_partition_info partition in
+  let new_partition =
+    make_new_partition partition start_sector sector_size new_size
 
 let mbr =
   let doc = "The disk image containing the partition" in

--- a/bin/write_partition.ml
+++ b/bin/write_partition.ml
@@ -29,14 +29,13 @@ let copy ic oc max_bytes =
   let buf = Bytes.create buf_len in
   let rec loop i =
     let len = input ic buf 0 buf_len in
-    if len > 0 then
+    if len > 0 then (
       let len' = min len (max_bytes - i) in
       output oc buf 0 len';
       if i + len > max_bytes then
         failwith "Trying to write more than can fit in partition";
-      loop (i + len')
-    else
-      ()
+      loop (i + len'))
+    else ()
   in
   loop 0
 
@@ -46,11 +45,11 @@ let write_to_partition mbr partition_number input_data =
     calculate_partition_info partition
   in
   if start_sector = 0 then
-    Printf.ksprintf failwith "Writing to partition %d would overwrite the MBR header" partition_number;
+    Printf.ksprintf failwith
+      "Writing to partition %d would overwrite the MBR header" partition_number;
   let ic, data_size =
     match input_data with
-    | None ->
-        (stdin, None)
+    | None -> (stdin, None)
     | Some file_path ->
         let file_info = Unix.stat file_path in
         let data_size = file_info.st_size in
@@ -58,12 +57,14 @@ let write_to_partition mbr partition_number input_data =
         (ic, Some data_size)
   in
   let partition_size = num_sectors * sector_size in
-  Option.iter (fun data_size ->
-      Printf.printf "Total input size: %d\n" data_size)
+  Option.iter
+    (fun data_size -> Printf.printf "Total input size: %d\n" data_size)
     data_size;
   Printf.printf "Total Partition size: %d\n" partition_size;
-  Option.iter (fun data_size ->
-      if data_size > partition_size then failwith "Input is too large for partition")
+  Option.iter
+    (fun data_size ->
+      if data_size > partition_size then
+        failwith "Input is too large for partition")
     data_size;
   Printf.printf "\nBegin writing to partition:- \n";
   let oc = open_out_gen [ Open_wronly; Open_binary ] 0o644 mbr in


### PR DESCRIPTION
part of #14 
#  Resizing partitions in a disk image

## Outline
This PR introduces a new binary `resize_partition` which resizes a partition to a new size.
We are using the `cmdliner` package to read arguments from the command line. It also provides a helpful --help flag which can displays a user manual.
Basically we read in a disk image, `unmarshal` it's MBR header to get the partition table, grab the specific partition we want to resize. After getting this partition, we calculate a new `end_sector` and create a new partition changing only this `end_sector`. Then we swap this new partition with it's counterpart in the original partition table and create a new `mbr` header with the updated partition table. The new `mbr` header is then written back to the disk image, overwriting just the MBR header.

## Usage

After building, the command can be called with:

```sh
resize_partition test.img 2 4096
```
- test.img : The disk image which contains the partition.
- 2 : The partition number we want to resize.
- 4096: the new size of the partition

## Outputs
### Read initial disk image
```
dune exec -- bin/mbr_inspect.exe disk.img
MBR fields:
  original_physical_drive: 0
  seconds: 0
  minutes: 0
  hours: 0
  disk_signature: 3153ef95
  Partition 1:
    bootable: false
    chs_begin: (cylinders: 8, heads: 0, sectors: 2)
    ty: 83
    chs_end: (cylinders: 95, heads: 2, sectors: 23)
    lba_begin: 1
    size_sectors: 2006
  Partition 2:
    bootable: false
    chs_begin: (cylinders: 143, heads: 3, sectors: 32)
    ty: 83
    chs_end: (cylinders: 123, heads: 0, sectors: 26)
    lba_begin: 2047
    size_sectors: 1435
  Partition 3:
    bootable: false
    chs_begin: (cylinders: 31, heads: 2, sectors: 3)
    ty: 83
    chs_end: (cylinders: 159, heads: 3, sectors: 32)
    lba_begin: 3522
    size_sectors: 574
```

### Resize 3rd partition
```
dune exec -- bin/resize_partition.exe disk.img 3 307200
```

### Verify 3rd partition has been resized
```
MBR fields:
  original_physical_drive: 0
  seconds: 0
  minutes: 0
  hours: 0
  disk_signature: 3153ef95
  Partition 1:
    bootable: false
    chs_begin: (cylinders: 0, heads: 0, sectors: 0)
    ty: 83
    chs_end: (cylinders: 0, heads: 0, sectors: 0)
    lba_begin: 1
    size_sectors: 2006
  Partition 2:
    bootable: false
    chs_begin: (cylinders: 0, heads: 0, sectors: 0)
    ty: 83
    chs_end: (cylinders: 0, heads: 0, sectors: 0)
    lba_begin: 2047
    size_sectors: 1435
  Partition 3:
    bootable: false
    chs_begin: (cylinders: 0, heads: 0, sectors: 0)
    ty: 83
    chs_end: (cylinders: 0, heads: 0, sectors: 0)
    lba_begin: 3522
    size_sectors: 4122
```

### Resizing a partition which may overlap
```
dune exec -- bin/resize_partition.exe disk.img 1 5000000
resize_partition: internal error, uncaught exception:
                  Failure("Partitions overlap")
```
cc @reynir 