### PR TITLE
Script to create an MBR formatted disk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ To do items
 * Implement tools to manipulate MBR-formatted disk images
   to construct, inspect or fill partitions that can later
   be used in Mirage unikernels.
+  

--- a/bin/create_mbr_disk.ml
+++ b/bin/create_mbr_disk.ml
@@ -1,0 +1,67 @@
+open Cmdliner
+
+let create_mbr_disk destination partition_files =
+  let sector_size = Mbr.sizeof in
+  let num_partitions = List.length partition_files in
+  Printf.printf "Total partitions to create: %d\n" num_partitions;
+
+  let partition_sizes =
+    List.map (fun file -> (Unix.stat file).Unix.st_size) partition_files
+  in    
+
+  let partition_size = List.fold_left (+) 0 partition_sizes in
+  let mbr_size = Mbr.sizeof in
+  let total_size = partition_size + mbr_size in
+
+  Printf.printf "Total disk size: %d bytes\n"
+      total_size;
+
+  let partitions =
+    List.mapi (fun i size ->
+      Printf.printf "Creating partition: %d" (i+1);
+      let start_sector = (i + 1) * sector_size in
+      let num_sectors = (size + sector_size - 1) / sector_size in
+      match
+        Mbr.Partition.make ~active:false ~partition_type:6 (Int32.of_int start_sector) (Int32.of_int num_sectors)
+      with
+      | Ok partition ->
+          Printf.printf " - OK\n";
+          partition
+      | Error msg -> failwith msg
+    ) partition_sizes
+  in
+  
+  (* Mbr.make smart constructor checks for partition overlap, more than 1 active partitions and too many partitions *)
+  let mbr =
+    match Mbr.make partitions with
+    | Ok mbr -> mbr
+    | Error msg -> failwith ("Failed to create MBR: " ^ msg)
+  in  
+
+  let oc = open_out_gen [ Open_wronly; Open_binary; Open_creat; Open_trunc ] 0o644 destination in
+  seek_out oc (total_size - 1);  (* Seek to the last byte of the file *)
+  output_byte oc 0;  (* Write a single byte to extend the file size *)
+  close_out oc;
+
+  let oc = open_out_bin destination in
+  let mbr_buffer = Cstruct.create Mbr.sizeof in
+  Mbr.marshal mbr_buffer mbr;
+  output oc (Cstruct.to_bytes mbr_buffer) 0 Mbr.sizeof;
+  close_out oc;
+  Unix.truncate destination total_size
+
+let destination =
+  let doc = "Output file for the MBR formatted disk image" in
+  Arg.(required & opt (some string) None & info ["d"; "destination"] ~docv:"destination" ~doc)
+
+let partition_files =
+  let doc = "Data files to be written to the partitions" in
+  Arg.(value & pos_all file [] & info [] ~docv:"partition_files" ~doc)
+
+let cmd =
+  let doc = "Create an MBR formatted disk image with an MBR header." in
+  let info = Cmd.info "create_mbr_disk" ~version:"1.0.0" ~doc in
+  Cmd.v info Term.(const create_mbr_disk $ destination $ partition_files)
+
+let main () = exit (Cmd.eval cmd)
+let () = main ()

--- a/bin/create_mbr_disk.ml
+++ b/bin/create_mbr_disk.ml
@@ -7,41 +7,37 @@ let create_mbr_disk destination partition_files =
 
   let partition_sizes =
     List.map (fun file -> (Unix.stat file).Unix.st_size) partition_files
-  in    
+  in
 
-  let partition_size = List.fold_left (+) 0 partition_sizes in
+  let partition_size = List.fold_left ( + ) 0 partition_sizes in
   let mbr_size = Mbr.sizeof in
   let total_size = partition_size + mbr_size in
 
-  Printf.printf "Total disk size: %d bytes\n"
-      total_size;
+  Printf.printf "Total disk size: %d bytes\n" total_size;
 
   let partitions =
-    List.mapi (fun i size ->
-      Printf.printf "Creating partition: %d" (i+1);
-      let start_sector = (i + 1) * sector_size in
-      let num_sectors = (size + sector_size - 1) / sector_size in
-      match
-        Mbr.Partition.make ~active:false ~partition_type:6 (Int32.of_int start_sector) (Int32.of_int num_sectors)
-      with
-      | Ok partition ->
-          Printf.printf " - OK\n";
-          partition
-      | Error msg -> failwith msg
-    ) partition_sizes
+    List.mapi
+      (fun i size ->
+        Printf.printf "Creating partition: %d" (i + 1);
+        let start_sector = (i + 1) * sector_size in
+        let num_sectors = (size + sector_size - 1) / sector_size in
+        match
+          Mbr.Partition.make ~active:false ~partition_type:1
+            (Int32.of_int start_sector)
+            (Int32.of_int num_sectors)
+        with
+        | Ok partition ->
+            Printf.printf " - OK\n";
+            partition
+        | Error msg -> failwith msg)
+      partition_sizes
   in
-  
   (* Mbr.make smart constructor checks for partition overlap, more than 1 active partitions and too many partitions *)
   let mbr =
     match Mbr.make partitions with
     | Ok mbr -> mbr
     | Error msg -> failwith ("Failed to create MBR: " ^ msg)
-  in  
-
-  let oc = open_out_gen [ Open_wronly; Open_binary; Open_creat; Open_trunc ] 0o644 destination in
-  seek_out oc (total_size - 1);  (* Seek to the last byte of the file *)
-  output_byte oc 0;  (* Write a single byte to extend the file size *)
-  close_out oc;
+  in
 
   let oc = open_out_bin destination in
   let mbr_buffer = Cstruct.create Mbr.sizeof in
@@ -52,7 +48,10 @@ let create_mbr_disk destination partition_files =
 
 let destination =
   let doc = "Output file for the MBR formatted disk image" in
-  Arg.(required & opt (some string) None & info ["d"; "destination"] ~docv:"destination" ~doc)
+  Arg.(
+    required
+    & opt (some string) None
+    & info [ "d"; "destination" ] ~docv:"destination" ~doc)
 
 let partition_files =
   let doc = "Data files to be written to the partitions" in

--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executables
- (names mbr_inspect read_partition write_partition resize_partition)
+ (names mbr_inspect read_partition write_partition resize_partition create_mbr_disk)
  (libraries mbr cstruct cmdliner unix))

--- a/bin/mbr_inspect.ml
+++ b/bin/mbr_inspect.ml
@@ -30,7 +30,9 @@ let print_mbr_fields print_bootstrap_code mbr =
         cylinders heads sectors;
       Printf.printf "    lba_begin: %ld\n"
         part.Mbr.Partition.first_absolute_sector_lba;
-      Printf.printf "    size_sectors: %ld\n" part.Mbr.Partition.sectors)
+      Printf.printf "    size_sectors: %ld\n" part.Mbr.Partition.sectors;
+      let partition_size = Int64.mul (Int64.of_int32 part.Mbr.Partition.sectors) (Int64.of_int Mbr.sizeof) in
+      Printf.printf "    Total Partition Size: %Ld bytes\n" partition_size)
     mbr.partitions
 
 let read_mbrs print_bootstrap_code mbrs =

--- a/bin/mbr_inspect.ml
+++ b/bin/mbr_inspect.ml
@@ -11,6 +11,18 @@ let print_mbr_fields print_bootstrap_code mbr =
   Printf.printf "  minutes: %d\n" mbr.Mbr.minutes;
   Printf.printf "  hours: %d\n" mbr.Mbr.hours;
   Printf.printf "  disk_signature: %lx\n" mbr.Mbr.disk_signature;
+  let total_disk_size =
+    List.fold_left
+      (fun acc part ->
+        let partition_size =
+          Int64.mul
+            (Int64.of_int32 part.Mbr.Partition.sectors)
+            (Int64.of_int Mbr.sizeof)
+        in
+        Int64.add acc partition_size)
+      Int64.zero mbr.partitions
+  in
+  Printf.printf "  disk_size: %Ld bytes\n" total_disk_size;
   List.iteri
     (fun i part ->
       let chs_begin = part.Mbr.Partition.first_absolute_sector_chs in
@@ -31,8 +43,12 @@ let print_mbr_fields print_bootstrap_code mbr =
       Printf.printf "    lba_begin: %ld\n"
         part.Mbr.Partition.first_absolute_sector_lba;
       Printf.printf "    size_sectors: %ld\n" part.Mbr.Partition.sectors;
-      let partition_size = Int64.mul (Int64.of_int32 part.Mbr.Partition.sectors) (Int64.of_int Mbr.sizeof) in
-      Printf.printf "    Total Partition Size: %Ld bytes\n" partition_size)
+      let partition_size =
+        Int64.mul
+          (Int64.of_int32 part.Mbr.Partition.sectors)
+          (Int64.of_int Mbr.sizeof)
+      in
+      Printf.printf "    partition_size: %Ld bytes\n" partition_size)
     mbr.partitions
 
 let read_mbrs print_bootstrap_code mbrs =


### PR DESCRIPTION
closes #14 

This PR tackles the final task of issue #14. 

Helpful notes from @reynir : 

>The idea was to pass zero or more files with partition data, some options and a destination and it would write a disk image to the destination with a MBR header and partitions containing the data. I think what I meant with padding was partitions larger than the input data - so containing either zeroes or uninitialized data at the end. And empty sections would be space in between partitions.
>

Currently we are able to achieve the following:
- Pass in a destination and some files: The number of files passed gives the number of partitions (max 4)
- Partition sizes: The sizes of the files are used to calculate the sizes that are allocated for each partition
- Writing the files to the partitions themselves can be achieved with the script [write_partition](https://github.com/mirage/ocaml-mbr/blob/master/bin/write_partition.ml)
- Inspecting the MBR structure in the newly created disk can be achieved with the script [mbr_inspect](https://github.com/mirage/ocaml-mbr/blob/master/bin/mbr_inspect.ml)
- Reading the contents of the partition or what has been written to it can be done with the script [read_partition](https://github.com/mirage/ocaml-mbr/blob/master/bin/read_partition.ml)
- Resizing the partition can be done with the script [resize_partition](https://github.com/mirage/ocaml-mbr/blob/master/bin/resize_partition.ml)


This new script can be compiled and executed by running:
```
dune exec -- bin/create_mbr_disk.exe -d disk.img notes.txt
```

- `disk.img`: The destination (the disk image that will be created in the current directory)
- `notes.txt`: A sample file 

The above command will create a disk file named `disk.img` with one partition which has a size equivalent to the size of notes.txt

A helpful menu can be opened by `dune exec -- bin/create_mbr_disk.exe --help`


Notes:
Some modifications will have to be made to accommodate features like paddings between partitions and restricting how many files should be passed with the script. This PR serves as a starting point.